### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,8 @@ jobs:
     
   test:
     name: Test
+    permissions:
+      contents: read
     needs: options
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ needs.options.outputs.mode == 'report' }}


### PR DESCRIPTION
Potential fix for [https://github.com/sede-open/setup-fortran/security/code-scanning/2](https://github.com/sede-open/setup-fortran/security/code-scanning/2)

To address the problem, we need to add a `permissions` block to the `test` job (starting at line 59) within `.github/workflows/test.yml`. The minimal safe default is `contents: read`, which restricts the GITHUB_TOKEN to read-only access for repository contents (source code, etc.). This matches best practices and the recommendations given. The block should be inserted beneath the job name (line 59 or 60), before the `needs`, `runs-on`, and other settings. No new imports, definitions, or library installations are needed, only a change to the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
